### PR TITLE
added path so that the database will be created in the DB folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 .env
 db/bangazon.sqlite
+bangazon.sqlite

--- a/db/build-db.js
+++ b/db/build-db.js
@@ -1,5 +1,5 @@
 const sqlite3 = require('sqlite3').verbose();
-const db = new sqlite3.Database(__dirname'/bangazon.sqlite');
+const db = new sqlite3.Database(__dirname+'/bangazon.sqlite');
 
 const { generateProdTypes, generateProducts } = require('./products-db.js');
 const { generateUsers } = require('./users-db');

--- a/db/build-db.js
+++ b/db/build-db.js
@@ -1,5 +1,5 @@
 const sqlite3 = require('sqlite3').verbose();
-const db = new sqlite3.Database('bangazon.sqlite');
+const db = new sqlite3.Database(__dirname'/bangazon.sqlite');
 
 const { generateProdTypes, generateProducts } = require('./products-db.js');
 const { generateUsers } = require('./users-db');


### PR DESCRIPTION
I added "dirname" to the path in the top of the db-builder because we want the database (.sqlite) file to be generated in the DB folder rather than the root.

I also added the sqlite file to the gitignore root level, just in case it ends up being generated in the root.


