### PR TITLE
added functionality to put and delete orders to order model, controll…

### DIFF
--- a/controllers/ordersCtrl.js
+++ b/controllers/ordersCtrl.js
@@ -1,5 +1,5 @@
  'use strict'
-const{getOrders, getOneOrder, postOrderObj}= require('../models/Order');
+const{getOrders, getOneOrder, postOrderObj, deleteOneOrder, putOrder}= require('../models/Order');
 
 module.exports.getAll=(req, res, next)=>{
     getOrders()//from models folder
@@ -31,6 +31,24 @@ module.exports.postOrder = (req, res, next) => {
         next(err);
     })
 }
+
+module.exports.putOrder = (req, res, next) => {
+    putOrder(req.params.id, req.body)
+    .then((data) => {
+        res.status(200).end();
+    })
+    .catch((err)=>{
+        next(err);
+    })
+}
+
+module.exports.deleteOneOrder = ({params: {id}}, res, next) => {
+    deleteOneOrder(id)
+    .then( () => {
+        res.status(200).end();
+    })
+    .catch( (err) => next(err));
+};
 
 //do module.exports for other methods here:  PUT  if necessary
 

--- a/models/Order.js
+++ b/models/Order.js
@@ -52,6 +52,28 @@ module.exports ={
         });
     }
 
+    deleteOneOrder:(id)=>{
+        return new Promise((resolve, reject)=>{//select order by order id and delete a single order 
+            db.run(`DELETE 
+                FROM orders
+                WHERE order_id = ${id}`, (err, order)=>{
+                if (err) return reject(err);
+                resolve(order);
+                });
+        });
+    },
+
+    putOrder:(id, orderObj) => { //need whole orderObj, but use the passed in ID from the req.params in order to access that number even after the object has been deleted from the DB
+        return new Promise( (resolve, reject) => {
+            db.run(`DELETE FROM orders WHERE order_id=${id}`)
+            db.run(`INSERT INTO orders VALUES (${id}, "${orderObj.order_date}", ${orderObj.payment_type}, ${orderObj.buyer_id}`
+                , (err, order)=>{
+                if (err) return reject(err);
+                resolve(order);
+                });
+        });
+    }
+
 //post, put, patch, delete (whatever's required) also here for order
 //exporting methods with value of promises to be called and resolved in controller
 }

--- a/models/Order.js
+++ b/models/Order.js
@@ -50,7 +50,7 @@ module.exports ={
                 resolve(order);
                 });
         });
-    }
+    },
 
     deleteOneOrder:(id)=>{
         return new Promise((resolve, reject)=>{//select order by order id and delete a single order 

--- a/models/Order.js
+++ b/models/Order.js
@@ -66,7 +66,7 @@ module.exports ={
     putOrder:(id, orderObj) => { //need whole orderObj, but use the passed in ID from the req.params in order to access that number even after the object has been deleted from the DB
         return new Promise( (resolve, reject) => {
             db.run(`DELETE FROM orders WHERE order_id=${id}`)
-            db.run(`INSERT INTO orders VALUES (${id}, "${orderObj.order_date}", ${orderObj.payment_type}, ${orderObj.buyer_id}`
+            db.run(`INSERT INTO orders VALUES (${id}, "${orderObj.order_date}", ${orderObj.payment_type}, ${orderObj.buyer_id})`
                 , (err, order)=>{
                 if (err) return reject(err);
                 resolve(order);

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -4,11 +4,13 @@ const{Router}= require('express');
 const router = Router();
 
 //require in controller method calls
-const{getAll, getOneOrderById, postOrder}= require('../controllers/ordersCtrl');//along with methods for post put etc...
+const{getAll, getOneOrderById, postOrder, deleteOneOrder, putOrder}= require('../controllers/ordersCtrl');//along with methods for post put etc...
 
 router.get('/orders', getAll);//if this route, get all
 router.get('/orders/:id', getOneOrderById);//if this route, get one using id passed in url
 router.post('/orders', postOrder);
+router.delete('/orders/:id', deleteOneOrder);
+router.put('/orders/:id', putOrder);
 
 
 module.exports = router;


### PR DESCRIPTION
I made the following changes:
- added functionality to put and delete orders to order model, controller, and routes

reason: to fulfill requirements for put and delete on this database table

To test:
- run ```npm run db:reset``` to create the database
- run ```npm start``` 
- open up a browser window to use with testing the "gets" below
_______________________________________________
- open POSTMAN app in chrome
- set it to DELETE
- test deleting one order by entering this url:
    localhost:8080/bangazonAPI/v1/orders/[id](order id you want to delete)
- send request
- check database to see if item in database was deleted
_______________________________________________
- open POSTMAN app in chrome
- set it to PUT
- test PUT a product by entering this url:
   localhost:8080/bangazonAPI/v1/orders/[id](order id you want to edit)
- make sure to set the body to JSON format
- insert an object to post with the properties listed in the database and the information you wish to 
   post
- make sure there is no ID
- send request
- check database for information entered