### PR TITLE
"add put and delete functionality for Payment Options"

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ require('dotenv').config();
 let bodyParser = require('body-parser');
 let routes = require('./routes/');
 
-
+app.use(bodyParser.urlencoded({extended:false}));
 app.use(bodyParser.json());
 
 app.get('/', (req, res, next)=>{
@@ -25,9 +25,10 @@ app.use((req, res, next)=>{
 });
 
 app.use((err, req, res, next)=>{
+    console.log(err)
     res.status(err.status||500);
     res.json({
-	message:"A problem occurred.",
+    message:"A problem occurred.",
 	err:err
     })
 });

--- a/controllers/paymentOptionsCtrl.js
+++ b/controllers/paymentOptionsCtrl.js
@@ -31,7 +31,6 @@ module.exports.postPmtOption = (req, res, next) => {
 
 //takes an ID and replaces the corresponding payment type
 module.exports.replacePaymentOption = (req, res, next) => {
-    console.log ("req.body");
     replacePayment(req.params.id, req.body)//id and object with payment info passed in here
     .then( (data) => {
         res.status(200).end();//new object posted

--- a/controllers/paymentOptionsCtrl.js
+++ b/controllers/paymentOptionsCtrl.js
@@ -2,16 +2,14 @@
 
 //export getAllPmtOptions, getOnePmtOptionById, postPmtOption
 //require in models files for payment options
-const{getPayments, getOnePayment, postPayment}= require('../models/PaymentOption'); //and whatever other methods exported
+const{getPayments, getOnePayment, postPayment, replacePayment, deletePayment}= require('../models/PaymentOption'); //and whatever other methods exported
 
 module.exports.getAllPmtOptions=(req, res, next)=>{
     getPayments()//from models folder
     .then((pmtOptions)=>{
         res.status(200).json(pmtOptions);
     })
-    .catch((err)=>{
-        next(err);
-    })
+    .catch((err)=> next(err));
 };
 
 module.exports.getOnePmtOptionById =(req, res, next)=>{
@@ -19,9 +17,7 @@ module.exports.getOnePmtOptionById =(req, res, next)=>{
     .then((pmtOpt)=>{
         res.status(200).json(pmtOpt);
     })
-    .catch((err)=>{
-        next(err);
-    })
+    .catch((err)=> next(err));
 }
 
 //dev must set postman to JSON format for these too.
@@ -30,10 +26,26 @@ module.exports.postPmtOption = (req, res, next) => {
     .then((data) => {
         res.status(200);
     })
-    .catch((err)=>{
-        next(err);
-    })
+    .catch((err)=> next(err));
 }
 
+//takes an ID and replaces the corresponding payment type
+module.exports.replacePaymentOption = (req, res, next) => {
+    console.log ("req.body");
+    replacePayment(req.params.id, req.body)//id and object with payment info passed in here
+    .then( (data) => {
+        res.status(200).end();//new object posted
+    })
+    .catch( (err) => next(err));
+};
+
+//takes an ID and deletes corresponding payment type
+module.exports.deletePaymentOption = ({params: {id}}, res, next) => {
+    deletePayment(id)
+    .then( () => {
+        res.status(200).end();
+    })
+    .catch( (err) => next(err));
+};
 //do module.exports for other methods here:  PUT & DELETE
 

--- a/db/build-db.js
+++ b/db/build-db.js
@@ -102,13 +102,6 @@ db.serialize( () => {
         returned_date TEXT NOT NULL
     )`);
 
-//run faker data for TRAINING table
-    let training = generateTraining();
-    training.forEach((trainingObj) => {
-        db.run(`INSERT INTO training (program_name, start_date, end_date, max_attendees) VALUES ("${trainingObj.program_name}", 
-            "${trainingObj.start_date}", "${trainingObj.end_date}", ${trainingObj.max_attendees})`);
-    });
-
 //users
     let usersArray = generateUsers();
     usersArray.forEach( (userObj) => {

--- a/models/PaymentOption.js
+++ b/models/PaymentOption.js
@@ -40,7 +40,6 @@ module.exports ={
 
     replacePayment:(id, pmtObj) =>{//same as payment object above with post, just replacing it
         //use id and payment object passed in to find object to replace and replace it with new values passed in in pmt object
-        console.log ("paymentObj?", pmtObj);
         return new Promise((resolve, reject)=>{
             db.run(`UPDATE paymentOptions
             SET payment_id = ${id}, buyer_id = ${pmtObj.buyer_id}, payment_option_name = "${pmtObj.payment_option_name}", account_number =${pmtObj.account_number}

--- a/models/PaymentOption.js
+++ b/models/PaymentOption.js
@@ -36,8 +36,29 @@ module.exports ={
                 resolve(pmt);
                 });
         });
+    },
+
+    replacePayment:(id, pmtObj) =>{//same as payment object above with post, just replacing it
+        //use id and payment object passed in to find object to replace and replace it with new values passed in in pmt object
+        console.log ("paymentObj?", pmtObj);
+        return new Promise((resolve, reject)=>{
+            db.run(`UPDATE paymentOptions
+            SET payment_id = ${id}, buyer_id = ${pmtObj.buyer_id}, payment_option_name = "${pmtObj.payment_option_name}", account_number =${pmtObj.account_number}
+            WHERE payment_id = ${id}`, (err, payment) => {
+                if (err) return reject(err);
+                resolve(payment);
+            });
+        })
+    },
+
+    deletePayment:(id) => {
+        return new Promise( (resolve, reject) => {
+            db.run(`DELETE FROM paymentOptions WHERE payment_id = ${id}`, (err) => {
+                if (err) return reject(err);
+                resolve();
+            });
+        })
     }
 
- // put, delete (whatever's required) also need to be done here
 
  }

--- a/routes/paymentOptions.js
+++ b/routes/paymentOptions.js
@@ -4,11 +4,13 @@ const{Router}= require('express');
 const router = Router();
 
 //require in controller method calls
-const{getAllPmtOptions, getOnePmtOptionById, postPmtOption}= require('../controllers/paymentOptionsCtrl');//along with methods for post put etc...
+const{getAllPmtOptions, getOnePmtOptionById, postPmtOption, replacePaymentOption, deletePaymentOption }= require('../controllers/paymentOptionsCtrl');//along with methods for post put etc...
 
+router.put('/payments/:id', replacePaymentOption);
 router.get('/payments', getAllPmtOptions);//if this route, get all
 router.get('/payments/:id', getOnePmtOptionById);//if this route, get one using id passed in url
 router.post('/payments', postPmtOption);
+router.delete('/payments/:id', deletePaymentOption);
 
 
 module.exports = router;


### PR DESCRIPTION
I made the following changes:
- added put and delete functionality for Payment Options
reason: to fulfill requirements.

Steps to test:
- run ```npm run db:reset``` to establish database
- run ```npm start```

To test PUT:
- open browser and go to  localhost:8080/bangazonAPI/v1/payments to get a listing of all items in the database as a sample, and copy the object you want to modify
- open Postman in Google Chrome 
- set url to localhost:8080/bangazonAPI/v1/payments/[id](payment id # that already exists in the database)
-set to PUT 
-paste the object into the BODY tab with that payment_id that you want to modify and change the property values
- make sure that the body is set to JSON format
- send the request 
- check to see if the object was modified in the database or do a get in the browser again to see

To test DELETE:
- open browser and go to  localhost:8080/bangazonAPI/v1/payments to get a listing of all items in the database as a sample, and get the id of the object you want to delete
- open Postman in Google Chrome 
- set url to localhost:8080/bangazonAPI/v1/payments/[id](payment id # that already exists in the database)
-set to DELETE
- send the request 
- check the database and make sure the row was deleted.

Refer to issue #3 