### PR TITLE
El orders have products

### DIFF
--- a/models/Order.js
+++ b/models/Order.js
@@ -1,4 +1,4 @@
- //delegate methods for querying database with promises here
+  //delegate methods for querying database with promises here
 
 'use strict';
 
@@ -37,15 +37,17 @@ module.exports ={
                 LEFT JOIN products ON products.product_id = productOrders.product_id
                 WHERE orders.order_id = ${id}
                 `, (err, order)=>{
+                    console.log(order);
                     if (err) return reject(err);
-                    resolve(formatOrder(order));
+                    if (order.length) resolve(formatOrder(order));
+                    else return reject("No such ID");
                 });
         });
     },
 
     postOrderObj:(orderObj) => { //this orderObj is the req.body passed from the ordersCtrl
         return new Promise((resolve, reject)=>{
-            db.run(`INSERT INTO orders VALUES (null, "${orderObj.order_date}", ${orderObj.payment_type}, ${orderObj.buyer_id})`, (err, order)=>{
+            db.run(`INSERT INTO orders VALUES (null, "${orderObj.order_date}", ${orderObj.payment_type} OR NULL, ${orderObj.buyer_id})`, (err, order)=>{
                 if (err) return reject(err);
                 resolve(order);
                 });

--- a/models/Order.js
+++ b/models/Order.js
@@ -45,12 +45,13 @@ module.exports ={
         });
     },
 
-    postOrderObj:(orderObj) => { //this orderObj is the req.body passed from the ordersCtrl
-        //must have a product id on it as well, for the join table.
+    postOrderObj:(orderObj) => { //this orderObj is the req.body passed from the ordersCtrl which must have a product id on it as well, for the join table
         return new Promise((resolve, reject)=>{
             db.run(`INSERT INTO orders VALUES (null, "${orderObj.order_date}", null, ${orderObj.buyer_id})`, 
-                function () {
-                    db.run(`INSERT INTO productOrders VALUES (${this.lastID}, ${orderObj.product_id}, null)`, (err, order) => {
+                function () { //have to use word "function" because of the "this"
+                //this db.run uses the property this.lastID which is able to get the PK from the row generated in the function for which this is a callback (the above). The null argument is for the PK of the line_item_id.
+                    db.run(`INSERT INTO productOrders VALUES (${this.lastID}, 
+                        ${orderObj.product_id}, null)`, (err, order) => {
                 if (err) return reject(err);
                 resolve(order);
                 });

--- a/models/Order.js
+++ b/models/Order.js
@@ -46,11 +46,15 @@ module.exports ={
     },
 
     postOrderObj:(orderObj) => { //this orderObj is the req.body passed from the ordersCtrl
+        //must have a product id on it as well, for the join table.
         return new Promise((resolve, reject)=>{
-            db.run(`INSERT INTO orders VALUES (null, "${orderObj.order_date}", ${orderObj.payment_type} OR NULL, ${orderObj.buyer_id})`, (err, order)=>{
+            db.run(`INSERT INTO orders VALUES (null, "${orderObj.order_date}", null, ${orderObj.buyer_id})`, 
+                function () {
+                    db.run(`INSERT INTO productOrders VALUES (${this.lastID}, ${orderObj.product_id}, null)`, (err, order) => {
                 if (err) return reject(err);
                 resolve(order);
                 });
+            })
         });
     },
 
@@ -65,6 +69,7 @@ module.exports ={
         });
     },
 
+//also especially for updating payment type to make the order complete!
     putOrder:(id, orderObj) => { //need whole orderObj, but use the passed in ID from the req.params in order to access that number even after the object has been deleted from the DB
         return new Promise( (resolve, reject) => {
             db.run(`DELETE FROM orders WHERE order_id=${id}`)

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -1,4 +1,4 @@
-'use strict'
+ 'use strict'
 
 const{Router}= require('express');
 const router = Router();


### PR DESCRIPTION
I made the following changes:
1. set the initial value of payment type to NULL for a new order
1. added a callback function to the POST order function, because we need to be able to include a product to initialize an order.

To test:

- npm start, and then get your postman set up to POST (raw, JSON).  
- put a JSON object in the body that has the properties of `order_date`, `buyer_id`, and `product_id` -- the payment type will default to null and PK autogenerates.
- check your DB browser or run the GETs to see that the new order has been created AND ALSO that the product and order are both entered in the join table. The new order should auto add itself to the join table with the first product.

#45 