### PR TITLE
Cait product orders

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,7 +21,7 @@ app.use(`/bangazonAPI/v1/`, routes); //require in routes so it will look in inde
 app.use((req, res, next)=>{
     let error = new Error('sorry, not found.');
     error.status = 404;
-    next(err);
+    next(error);
 });
 
 app.use((err, req, res, next)=>{

--- a/controllers/ordersCtrl.js
+++ b/controllers/ordersCtrl.js
@@ -51,6 +51,7 @@ module.exports.deleteOneOrder = ({params: {id}}, res, next) => {
 };
 
 module.exports.postProdOrder = (req, res, next) => {
+        console.log("whyyyyyy?", req);
     postProdOrderObj(req.body)
     .then((data) => {
         res.status(200).end('product order posted sucessfully');

--- a/controllers/ordersCtrl.js
+++ b/controllers/ordersCtrl.js
@@ -1,5 +1,5 @@
  'use strict'
-const{getOrders, getOneOrder, postOrderObj, deleteOneOrder, putOrder}= require('../models/Order');
+const{getOrders, getOneOrder, postOrderObj, postProdOrderObj, deleteOneOrder, deleteOneProdOrder, putOrder}= require('../models/Order');
 
 module.exports.getAll=(req, res, next)=>{
     getOrders()//from models folder
@@ -44,6 +44,24 @@ module.exports.putOrder = (req, res, next) => {
 
 module.exports.deleteOneOrder = ({params: {id}}, res, next) => {
     deleteOneOrder(id)
+    .then( () => {
+        res.status(200).end();
+    })
+    .catch( (err) => next(err));
+};
+
+module.exports.postProdOrder = (req, res, next) => {
+    postProdOrderObj(req.body)
+    .then((data) => {
+        res.status(200).end('product order posted sucessfully');
+    })
+    .catch((err)=>{
+        next(err);
+    })
+}
+
+module.exports.deleteOneProdOrder = ({params: {id}}, res, next) => {
+    deleteOneProdOrder(id)
     .then( () => {
         res.status(200).end();
     })

--- a/controllers/ordersCtrl.js
+++ b/controllers/ordersCtrl.js
@@ -51,7 +51,6 @@ module.exports.deleteOneOrder = ({params: {id}}, res, next) => {
 };
 
 module.exports.postProdOrder = (req, res, next) => {
-        console.log("whyyyyyy?", req);
     postProdOrderObj(req.body)
     .then((data) => {
         res.status(200).end('product order posted sucessfully');

--- a/models/Order.js
+++ b/models/Order.js
@@ -6,6 +6,7 @@ let sqlite3 = require ('sqlite3').verbose();
 let db = new sqlite3.Database('./db/bangazon.sqlite');
 
 let formatOrder = (order) => {
+    // console.log("order", order);
     let formattedOrder = {
         "order_id": order[0].order_id,
         "order_date": order[0].order_date,
@@ -13,7 +14,7 @@ let formatOrder = (order) => {
         "products": []
     };
     order.forEach(orderItem => {
-        formattedOrder.products.push({"product_id": orderItem.product_id, "name": orderItem.product_name, "price": orderItem.price, "quantity": orderItem.quantity_avail});
+        formattedOrder.products.push({"product_id": orderItem.product_id, "name": orderItem.product_name, "price": orderItem.price, "quantity": orderItem.quantity_avail, "line_item_id": orderItem.line_item_id});
     })
     return formattedOrder
 }
@@ -57,8 +58,14 @@ module.exports ={
             db.run(`DELETE 
                 FROM orders
                 WHERE order_id = ${id}`, (err, order)=>{
-                if (err) return reject(err);
-                resolve(order);
+                    if (err) return reject(err);
+                    resolve(order);
+                });
+            db.run(`DELETE
+                FROM productOrders
+                WHERE order_id = ${id}`, (err, prodOrder) => {
+                    if (err) return reject(err);
+                    resolve(prodOrder);
                 });
         });
     },
@@ -72,7 +79,27 @@ module.exports ={
                 resolve(order);
                 });
         });
-    }
+    },
+
+    postProdOrderObj:(prodOrderObj) => { //this prodOrderObj is the req.body passed from the ordersCtrl
+        return new Promise((resolve, reject)=>{
+            db.run(`INSERT INTO productOrders VALUES (null, "${prodOrderObj.order_id}", ${prodOrderObj.product_id})`, (err, prodOrder)=>{
+                if (err) return reject(err);
+                resolve(prodOrder);
+                });
+        });
+    },
+
+    deleteOneProdOrder:(id)=>{
+        return new Promise((resolve, reject)=>{//select product order by product order id and delete a single product order 
+            db.run(`DELETE 
+                FROM productOrders
+                WHERE line_item_id = ${id}`, (err, prodOrder)=>{
+                if (err) return reject(err);
+                resolve(prodOrder);
+                });
+        });
+    },
 
 //post, put, patch, delete (whatever's required) also here for order
 //exporting methods with value of promises to be called and resolved in controller

--- a/models/Order.js
+++ b/models/Order.js
@@ -82,8 +82,8 @@ module.exports ={
     putOrder:(id, orderObj) => { //need whole orderObj, but use the passed in ID from the req.params in order to access that number even after the object has been deleted from the DB
         return new Promise( (resolve, reject) => {
             db.run(`UPDATE orders 
-                WHERE order_id = ${id};
-                SET order_date = "${orderObj.order_date}", payment_type = ${orderObj.payment_type}, buyer_id = ${orderObj.buyer_id}`
+                SET order_date = "${orderObj.order_date}", payment_type = ${orderObj.payment_type}, buyer_id = ${orderObj.buyer_id}
+                WHERE order_id = ${id}`
                 , (err, order)=>{
                 if (err) return reject(err);
                 resolve(order);

--- a/models/Order.js
+++ b/models/Order.js
@@ -73,8 +73,7 @@ module.exports ={
 //updates an existing order in the order table
     putOrder:(id, orderObj) => { //need whole orderObj, but use the passed in ID from the req.params in order to access that number even after the object has been deleted from the DB
         return new Promise( (resolve, reject) => {
-            db.run(`DELETE FROM orders WHERE order_id=${id}`)
-            db.run(`INSERT INTO orders VALUES (${id}, "${orderObj.order_date}", ${orderObj.payment_type}, ${orderObj.buyer_id})`
+            db.run(`UPDATE orders SET order_id = ${id}, order_date = "${orderObj.order_date}", payment_type = ${orderObj.payment_type}, buyer_id = ${orderObj.buyer_id}`
                 , (err, order)=>{
                 if (err) return reject(err);
                 resolve(order);
@@ -84,7 +83,6 @@ module.exports ={
 
 //this function posts to the productOrder join table with an order id and product id, it does not effect the order table
     postProdOrderObj:(prodOrderObj) => { //this prodOrderObj is the req.body passed from the ordersCtrl
-            console.log("why?", prodOrderObj);
         return new Promise((resolve, reject)=>{
             db.run(`INSERT INTO productOrders VALUES (${prodOrderObj.order_id}, ${prodOrderObj.product_id}, null)`
                 , (err, prodOrder)=>{

--- a/models/Order.js
+++ b/models/Order.js
@@ -49,7 +49,7 @@ module.exports ={
             db.run(`INSERT INTO orders VALUES (null, "${orderObj.order_date}", ${orderObj.payment_type}, ${orderObj.buyer_id})`, (err, order)=>{
                 if (err) return reject(err);
                 resolve(order);
-                });
+            });
         });
     },
 
@@ -60,16 +60,17 @@ module.exports ={
                 WHERE order_id = ${id}`, (err, order)=>{
                     if (err) return reject(err);
                     resolve(order);
-                });
+            });
             db.run(`DELETE
                 FROM productOrders
                 WHERE order_id = ${id}`, (err, prodOrder) => {
                     if (err) return reject(err);
                     resolve(prodOrder);
-                });
+            });
         });
     },
 
+//updates an existing order in the order table
     putOrder:(id, orderObj) => { //need whole orderObj, but use the passed in ID from the req.params in order to access that number even after the object has been deleted from the DB
         return new Promise( (resolve, reject) => {
             db.run(`DELETE FROM orders WHERE order_id=${id}`)
@@ -81,15 +82,19 @@ module.exports ={
         });
     },
 
+//this function posts to the productOrder join table with an order id and product id, it does not effect the order table
     postProdOrderObj:(prodOrderObj) => { //this prodOrderObj is the req.body passed from the ordersCtrl
+            console.log("why?", prodOrderObj);
         return new Promise((resolve, reject)=>{
-            db.run(`INSERT INTO productOrders VALUES (null, "${prodOrderObj.order_id}", ${prodOrderObj.product_id})`, (err, prodOrder)=>{
+            db.run(`INSERT INTO productOrders VALUES (${prodOrderObj.order_id}, ${prodOrderObj.product_id}, null)`
+                , (err, prodOrder)=>{
                 if (err) return reject(err);
                 resolve(prodOrder);
                 });
         });
     },
 
+//deletes a line item from the productOrder join table using the line item id primary key. it does not effect the order table
     deleteOneProdOrder:(id)=>{
         return new Promise((resolve, reject)=>{//select product order by product order id and delete a single product order 
             db.run(`DELETE 

--- a/models/Order.js
+++ b/models/Order.js
@@ -81,7 +81,9 @@ module.exports ={
 //also especially for updating payment type to make the order complete!
     putOrder:(id, orderObj) => { //need whole orderObj, but use the passed in ID from the req.params in order to access that number even after the object has been deleted from the DB
         return new Promise( (resolve, reject) => {
-            db.run(`UPDATE orders SET order_id = ${id}, order_date = "${orderObj.order_date}", payment_type = ${orderObj.payment_type}, buyer_id = ${orderObj.buyer_id}`
+            db.run(`UPDATE orders 
+                WHERE order_id = ${id};
+                SET order_date = "${orderObj.order_date}", payment_type = ${orderObj.payment_type}, buyer_id = ${orderObj.buyer_id}`
                 , (err, order)=>{
                 if (err) return reject(err);
                 resolve(order);

--- a/routes/index.js
+++ b/routes/index.js
@@ -18,7 +18,7 @@ router.get('/', (req, res)=>{
     "orders":"bangazonAPI/v1/orders",
     "products":"bangazonAPI/v1/products",
     "paymentOptions":"bangazonAPI/v1/payments",
-    "productOrders":"bangazonAPI/v1/productorders"
+    "productOrders":"bangazonAPI/v1/productorder"
     //etc
     });
 });

--- a/routes/index.js
+++ b/routes/index.js
@@ -17,7 +17,8 @@ router.get('/', (req, res)=>{
     "users":"bangazonAPI/v1/users",
     "orders":"bangazonAPI/v1/orders",
     "products":"bangazonAPI/v1/products",
-    "paymentOptions":"bangazonAPI/v1/payments"
+    "paymentOptions":"bangazonAPI/v1/payments",
+    "productOrders":"bangazonAPI/v1/productorders"
     //etc
     });
 });

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -4,13 +4,15 @@ const{Router}= require('express');
 const router = Router();
 
 //require in controller method calls
-const{getAll, getOneOrderById, postOrder, deleteOneOrder, putOrder}= require('../controllers/ordersCtrl');//along with methods for post put etc...
+const{getAll, getOneOrderById, postOrder, postProdOrder, deleteOneOrder, deleteOneProdOrder, putOrder}= require('../controllers/ordersCtrl');//along with methods for post put etc...
 
 router.get('/orders', getAll);//if this route, get all
 router.get('/orders/:id', getOneOrderById);//if this route, get one using id passed in url
 router.post('/orders', postOrder);
 router.delete('/orders/:id', deleteOneOrder);
 router.put('/orders/:id', putOrder);
+router.post('/productorder', postProdOrder);
+router.delete('/productorder/:id', deleteOneProdOrder);
 
 
 module.exports = router;


### PR DESCRIPTION
I made the following changes:
- added post and delete functionality for Product orders join table. product orders line items will now be deleted as well on order deletion.
-updated putOrder function in orders model to be an update sql statement vs delete/insert
reason: to fulfill requirements.

Steps to test:
- run ```npm run db:reset``` to establish database
- run ```npm start```

To test DELETE (you will have to check your database for existing product order entries to delete and add one if necessary):
- open browser and go to  localhost:8080/bangazonAPI/v1/order/id to get a listing of all products in the order. find the line_item_id for the product you want to delete from the order.
- open Postman in Google Chrome 
- set url to localhost:8080/bangazonAPI/v1/productorder/"line item id" for the product you want to delete from the order
-set to DELETE
- send the request 
- check the database and make sure the row was deleted.

open POSTMAN app in chrome
set it to POST
test add a product to an existing order, entering this url:
localhost:8080/bangazonAPI/v1/productorder
make sure to set the body to JSON format
insert an object to post with the properties listed in the database (order_id and product_id) and the information you wish to post
send request
-check database for information entered