### PR TITLE
GM_cascade

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,13 +18,13 @@ app.use(`/bangazonAPI/v1/`, routes); //require in routes so it will look in inde
 
 //other middleware?
 
-app.use((req, res, next)=>{
+app.use( (req, res, next) => {
     let error = new Error('sorry, not found.');
     error.status = 404;
-    next(err);
+    next(error);
 });
 
-app.use((err, req, res, next)=>{
+app.use( (err, req, res, next) => {
     console.log(err)
     res.status(err.status||500);
     res.json({
@@ -33,6 +33,6 @@ app.use((err, req, res, next)=>{
     })
 });
 
-app.listen(process.env.port || 8080, ()=>{
+app.listen(process.env.port || 8080, () => {
     console.log("Listening on port specified.");
 });

--- a/controllers/productTypesCtrl.js
+++ b/controllers/productTypesCtrl.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { getAll, getOne, addType, replaceType, deleteType } = require('../models/ProductType');
+const { getAll, getOne, addType, replaceType, deleteType, productTypeMatch } = require('../models/ProductType');
 
 //grabs all product types
 module.exports.getProductTypes = (req, res, next) => {
@@ -40,11 +40,29 @@ module.exports.replaceProductType = (req, res, next) => {
     .catch( (err) => next(err));
 };
 
-//takes an ID and deletes corresponding product type
+//deletes a specific product type as long as that type doesn't exist as a property on a product
 module.exports.deleteAProductType = ({params: {id}}, res, next) => {
-    deleteType(id)
-    .then( () => {
-        res.status(200).end();
+    productTypeMatch()//look for productType match
+    .then( (data) => { //data comes back as array - filter out
+        data.filter( (prodTypeObj) => {
+            if (prodTypeObj.product_type_id === null){
+                return prodTypeObj;  //return the objects that have product_type_id of null
+            }
+        }).map( (obj) => {//map through and return the type id numbers of the ones we can delete
+            return obj.type_id;
+        }).forEach( (num) => {
+            if(num == id){ //if number = id, delete it
+                deleteType(+id)//change id into number
+                .then( () => {
+                    res.end(); //res.status(200).end();  ?
+                })
+            }
+        })
+        res.end();//res.status(200).end();  ?
     })
-    .catch( (err) => next(err));
+    .catch((err)=>{
+        next(err);
+    });
+
 };
+

--- a/db/build-db.js
+++ b/db/build-db.js
@@ -73,7 +73,7 @@ db.serialize( () => {
     )`);
     db.run(`CREATE TABLE IF NOT EXISTS products(
         product_id INTEGER PRIMARY KEY NOT NULL,
-        type_id INTEGER NOT NULL,
+        product_type_id INTEGER NOT NULL,
         seller_id INTEGER NOT NULL,
         product_name TEXT NOT NULL,
         description TEXT NOT NULL,
@@ -118,7 +118,7 @@ db.serialize( () => {
 // products
     let productsArray = generateProducts();
     productsArray.forEach( (prodObj) => {
-        db.run(`INSERT INTO products (type_id, seller_id, product_name, description, quantity_avail, price) VALUES (${prodObj.type_id}, ${prodObj.seller_id}, "${prodObj.name}", "${prodObj.description}", ${prodObj.quantity}, ${prodObj.price})`);
+        db.run(`INSERT INTO products VALUES (null, ${prodObj.product_type_id}, ${prodObj.seller_id}, "${prodObj.name}", "${prodObj.description}", ${prodObj.quantity}, ${prodObj.price})`);
     });
 // payment_types
     let paymentOptsArray = generatePaymentOptions();

--- a/db/products-db.js
+++ b/db/products-db.js
@@ -8,7 +8,7 @@ module.exports.generateProdTypes = () => {
 
   for (let i = 0; i < 12; i++) {
     let label = faker.commerce.department();
-    
+
     prodTypes.push({
       label
     });
@@ -19,12 +19,12 @@ module.exports.generateProdTypes = () => {
 module.exports.generateProducts = () => {
   let products = [];
 
-  for (let i = 0; i < 50; i++) {
+  for (let i = 0; i < 10; i++) {
     let description = faker.random.words();
     let price = faker.commerce.price();
     let name = faker.commerce.productName();
     let quantity = faker.random.number();
-    let type_id = i%12 + 1;
+    let product_type_id = i%12 + 1;
     let seller_id = faker.random.number();
 
 
@@ -33,7 +33,7 @@ module.exports.generateProducts = () => {
       price,
       name,
       quantity,
-      type_id,
+      product_type_id,
       seller_id
     });
   }

--- a/models/ProductType.js
+++ b/models/ProductType.js
@@ -41,5 +41,17 @@ module.exports = {
                 resolve();
             });
         })
+    },
+    productTypeMatch:()=>{
+        return new Promise((resolve, reject)=>{
+            //if product_type_id exists inside products, don't delete the product type
+            db.all(`SELECT *
+            FROM productTypes
+            LEFT JOIN products
+            ON productTypes.type_id = products.product_type_id`, (err, data)=>{
+                if (err) return reject(err);
+                resolve(data);//list of all products matched with product types based on type_id
+            });
+        })
     }
 }


### PR DESCRIPTION
I made the following changes:

- modify faker insertion and build-db file to remove repetition of a database column name, 
- change delete functionality to protect product types from being deleted if they are used on a product

Reason:  We're trying to protect against a cascading effect when one item is deleted that needs to be used elsewhere.

Expected Behavior:
1. When the developer wishes to delete a Product Type that isn't used as a Foreign Key in Products they should be able to do so.

2. When the developer tries to delete a Product Type that is used as a Foreign Key in Products, they should not be able to do so.

To test:
- Run ```npm run db:reset``` if necessary to reset the database.
- Run ```npm start```
- Open Postman in Google Chrome.
- Set to DELETE.
- Set url to localhost:8080/bangazonAPI/v1/producttypes/[id](id of the product type to be deleted)
- Send request.
- Check database for that item.  If the product type is used on a product, it should not disappear, if it isn't used, it should.

Refer to issue #43 