### PR TITLE
add protection to payment options so they can't be deleted if used in order

### DIFF
--- a/models/PaymentOption.js
+++ b/models/PaymentOption.js
@@ -57,6 +57,18 @@ module.exports ={
                 resolve();
             });
         })
+    },
+    paymentTypeMatch:()=>{
+        return new Promise((resolve, reject)=>{
+            //if payment option exists inside orders, don't delete the payment type
+            db.all(`SELECT *
+            FROM paymentOptions
+            LEFT JOIN orders
+            ON paymentOptions.payment_id = orders.payment_type`, (err, data)=>{
+                if (err) return reject(err);
+                resolve(data);//list of all orders matched with payment types
+            });
+        })
     }
 
 


### PR DESCRIPTION
I made the following changes:
- change delete functionality to protect payment options from being deleted if they are used on an order

Reason: We're trying to protect against a cascading effect when one item is deleted that needs to be used elsewhere.

Expected Behavior:

1. When the developer wishes to delete a payment option that isn't used as a Foreign Key in Products they should be able to do so.

2. When the developer tries to delete a payment option that is used as a Foreign Key in Orders, they should not be able to do so.

To test:
- Run ```npm run db:reset``` if necessary to reset the database.
- Run ```npm start```.
- Open Postman in Google Chrome.
- Set to DELETE.
- Set url to localhost:8080/bangazonAPI/v1/payments/[id](id of the payment option to be deleted)

- Check database for that item. If the payment option is used on an order, it should not disappear, and if it isn't used in the orders table,  the payment option should disappear.

Refer to issue #43 