### PR TITLE
Cait delete no prod order

### DIFF
--- a/controllers/ordersCtrl.js
+++ b/controllers/ordersCtrl.js
@@ -63,7 +63,7 @@ module.exports.postProdOrder = (req, res, next) => {
 module.exports.deleteOneProdOrder = ({params: {id}}, res, next) => {
     deleteOneProdOrder(id)
     .then( () => {
-        res.status(200).end("Item deteled from order.");
+        res.status(200).end("Deleted if existed.");
     })
     .catch( (err) => next(err));
 };

--- a/controllers/ordersCtrl.js
+++ b/controllers/ordersCtrl.js
@@ -63,7 +63,7 @@ module.exports.postProdOrder = (req, res, next) => {
 module.exports.deleteOneProdOrder = ({params: {id}}, res, next) => {
     deleteOneProdOrder(id)
     .then( () => {
-        res.status(200).end();
+        res.status(200).end("Item deteled from order.");
     })
     .catch( (err) => next(err));
 };

--- a/models/Order.js
+++ b/models/Order.js
@@ -23,6 +23,7 @@ let deleteNoProdOrders = (id) => {
         return new Promise((resolve, reject)=>{
             db.all(`SELECT * FROM productOrders WHERE line_item_id = ${id}`, (err, lineId)=> {
                 if (err) return reject(err);
+                if (lineId[0]) {
                 db.all(`SELECT * FROM productOrders WHERE order_id = ${lineId[0].order_id}
                     `, (err, orderData)=>{
                     if (err) return reject(err);//if error, pass on to error handler
@@ -35,7 +36,8 @@ let deleteNoProdOrders = (id) => {
                             else {
                                 resolve("ELSE");
                             }
-                });
+                    });
+                }
             })
             resolve();
             

--- a/models/Order.js
+++ b/models/Order.js
@@ -19,6 +19,32 @@ let formatOrder = (order) => {
     return formattedOrder
 }
 
+let deleteNoProdOrders = (id) => {
+        return new Promise((resolve, reject)=>{
+            db.get(`SELECT order_id FROM productOrders WHERE line_item_id = ${id}`, (err, lineId)=> {
+                if (err) return reject(err);
+                db.all(`SELECT * 
+                    FROM productOrders
+                    WHERE order_id = ${lineId.order_id}
+                    `, (err, orderData)=>{
+                    if (err) return reject(err);//if error, pass on to error handler
+                    if (orderData.length < 2) {
+                        let deleteOrderId = parseInt(orderData[0].order_id)
+                        console.log("orderData", deleteOrderId);
+                        db.run(`DELETE 
+                        FROM orders
+                        WHERE order_id = deleteOrderId`, (err, order)=>{
+                            if (err) return reject(err);
+                            resolve(order);
+                        });
+                            }
+                            resolve(orderData);
+                });
+            })
+            
+        })
+}
+
 module.exports ={
     getOrders:()=>{//method that returns a promise-- see .then in ordersCtrl
         return new Promise((resolve, reject)=>{
@@ -105,10 +131,12 @@ module.exports ={
 //deletes a line item from the productOrder join table using the line item id primary key. it does not effect the order table
     deleteOneProdOrder:(id)=>{
         return new Promise((resolve, reject)=>{//select product order by product order id and delete a single product order 
+            deleteNoProdOrders(id);
             db.run(`DELETE 
                 FROM productOrders
                 WHERE line_item_id = ${id}`, (err, prodOrder)=>{
                 if (err) return reject(err);
+                
                 resolve(prodOrder);
                 });
         });


### PR DESCRIPTION
What we changed:
Created helper function to check if the order from which a product is being deleted has any other products on it; if NOT, the order is also deleted by the helper function. Either way, the row of the join table is deleted. This was because an order cannot exist without a product on it.


To test, 
open your DB browser and create some rows in the join table for experimental deletion. Enter a few products for the same order_id.
Use postman to delete them based on their line_item_id.
Check to see if the order in the orders table has been deleted once (but not before) the final product is deleted from that order.

#45 