### PR TITLE
Prevent user from deleting orders that are already closed

### DIFF
--- a/controllers/ordersCtrl.js
+++ b/controllers/ordersCtrl.js
@@ -1,7 +1,7 @@
- 'use strict'
-const { getOrders, getOneOrder, postOrderObj, postProdOrderObj, deleteOneOrder, deleteOneProdOrder, putOrder, getUsersOrders } = require('../models/Order');
+'use strict'
+const { getOrders, getOneOrder, postOrderObj, postProdOrderObj, removeOrderJoins, deleteOneOrder, deleteOneProdOrder, putOrder, getUsersOrders } = require('../models/Order');
 
-module.exports.getAll=(req, res, next)=>{
+module.exports.getAll = (req, res, next) => {
     getOrders()//from models folder
     .then( (orders) => {
         res.status(200).json(orders);
@@ -9,7 +9,7 @@ module.exports.getAll=(req, res, next)=>{
     .catch( (err) => next(err));
 }
 
-module.exports.getOneOrderById =(req, res, next)=>{
+module.exports.getOneOrderById = (req, res, next) => {
     getOneOrder(req.params.id)//method from User.js
     .then( (order) => {
         res.status(200).json(order);
@@ -36,6 +36,9 @@ module.exports.putOrder = (req, res, next) => {
 
 module.exports.deleteOneOrder = ({params: {id}}, res, next) => {
     deleteOneOrder(id)
+    .then( () => {
+        removeOrderJoins(id)
+    })
     .then( () => {
         res.status(200).end();
     })

--- a/controllers/ordersCtrl.js
+++ b/controllers/ordersCtrl.js
@@ -37,7 +37,6 @@ module.exports.putOrder = (req, res, next) => {
 module.exports.deleteOneOrder = ({params: {id}}, res, next) => {
     deleteOneOrder(id)
     .then( (changes) => {
-        console.log(changes);
         if (changes) return removeOrderJoins(id);
         else res.send('Cannot delete this historical item');
     })

--- a/controllers/ordersCtrl.js
+++ b/controllers/ordersCtrl.js
@@ -36,11 +36,13 @@ module.exports.putOrder = (req, res, next) => {
 
 module.exports.deleteOneOrder = ({params: {id}}, res, next) => {
     deleteOneOrder(id)
-    .then( () => {
-        removeOrderJoins(id)
+    .then( (changes) => {
+        console.log(changes);
+        if (changes) return removeOrderJoins(id);
+        else res.send('Cannot delete this historical item');
     })
     .then( () => {
-        res.status(200).end();
+        res.status(200).end('Order deleted');
     })
     .catch( (err) => next(err));
 }

--- a/models/Order.js
+++ b/models/Order.js
@@ -89,7 +89,6 @@ module.exports = {
             db.run(`DELETE 
                 FROM orders
                 WHERE order_id = ${id} AND payment_type IS NULL`, function(err) {
-                    console.log("this changes", this.changes);
                     if (err) return reject(err);
                     resolve(this.changes);
             });

--- a/models/Order.js
+++ b/models/Order.js
@@ -88,12 +88,25 @@ module.exports = {
         return new Promise( (resolve, reject) => {//select order by order id and delete a single order 
             db.run(`DELETE 
                 FROM orders
-                WHERE order_id = ${id} AND payment_type IS NULL`, (err, order) => {
+                WHERE order_id = ${id} AND payment_type IS NULL`, function(err) {
+                    console.log("this changes", this.changes);
                     if (err) return reject(err);
-                    resolve(order);
+                    resolve(this.changes);
             });
 
         });
+    },
+
+    removeOrderJoins:(id) => {
+        return new Promise ( (resolve, reject) => {
+            db.run(`DELETE
+            FROM productOrders
+            WHERE order_id = ${id}`, (err, prodOrder) => {
+                if (err) return reject(err);
+                resolve(prodOrder);
+            });
+       
+        })
     },
 
 //updates an existing order in the order table
@@ -135,18 +148,6 @@ module.exports = {
             })
 
         });
-    },
-
-    removeOrderJoins:(id) => {
-        return new Promise ( (resolve, reject) => {
-            db.run(`DELETE
-            FROM productOrders
-            WHERE order_id = ${id}`, (err, prodOrder) => {
-                if (err) return reject(err);
-                resolve(prodOrder);
-            });
-       
-        })
     },
 
 //returns all orders from the specified user

--- a/models/Order.js
+++ b/models/Order.js
@@ -17,6 +17,7 @@ let formatOrder = (order) => {
     return formattedOrder
 }
 
+
 let deleteNoProdOrders = (id) => {
         return new Promise((resolve, reject)=>{
             db.all(`SELECT * FROM productOrders WHERE line_item_id = ${id}`, (err, lineId)=> {
@@ -87,16 +88,11 @@ module.exports = {
         return new Promise( (resolve, reject) => {//select order by order id and delete a single order 
             db.run(`DELETE 
                 FROM orders
-                WHERE order_id = ${id}`, (err, order) => {
+                WHERE order_id = ${id} AND payment_type IS NULL`, (err, order) => {
                     if (err) return reject(err);
                     resolve(order);
             });
-            db.run(`DELETE
-                FROM productOrders
-                WHERE order_id = ${id}`, (err, prodOrder) => {
-                    if (err) return reject(err);
-                    resolve(prodOrder);
-            });
+
         });
     },
 
@@ -140,6 +136,19 @@ module.exports = {
 
         });
     },
+
+    removeOrderJoins:(id) => {
+        return new Promise ( (resolve, reject) => {
+            db.run(`DELETE
+            FROM productOrders
+            WHERE order_id = ${id}`, (err, prodOrder) => {
+                if (err) return reject(err);
+                resolve(prodOrder);
+            });
+       
+        })
+    },
+
 //returns all orders from the specified user
     getUsersOrders:(uid) => {
         return new Promise( (resolve, reject) => {


### PR DESCRIPTION
...keep recursive deletes of products from join table in event of deleted order.

What i changed:
I included "IS NULL" in the SQL call for payment_type delete function for an order. I also moved the function for recursive deletion of the join table items of a deleted order because I don't want the items deleted if the order is prevented from being deleted.

To test:

First do `npm start` and make sure you have a database and that it has some entries into the productOrder join table.  
- Then use postman to `POST` a new order, which will have the payment_type of _`NULL`_. This may not be the same as the string NULL. New entries default to NULL but our faker data includes payment types for all its orders.
- the JSON you need to POST will look like this:
 `{`
       ` "order_date": "Mon Oct 17 2016 20:12:47 GMT-0500 (Central Daylight Time)",  `
       ` "buyer_id": 34`
   ` }`
- Use `http://localhost:8080/bangazonAPI/v1/orders/`
 - Then, use postman to delete an order. Try deleting an order that has a payment type, and one that does not. Check to see if the join table items with that order ID remain or stay.

The ones with payment type on order should stay. Those without, should be deleted.

#43 