### PR TITLE
added product type documentation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,25 @@ __________________________________________
 #### PUT
 - `http://localhost:8080/bangazonAPI/v1/payments/[unique_payment_id]`
 - Takes a JSON object in the format specified above.
+_____________________________________________
+### To access the 'product types' resource
+#### GET all
+- `http://localhost:8080/bangazonAPI/v1/producttypes`
+- Returns all products in the following format:
+{
+    "type_id": 1,
+    "label": Electronics
+}
+#### GET one
+- `http://localhost:8080/bangazonAPI/v1/producttypes/[unique_product_type_id]`
+-Returns one product by its unique product type id.
+#### DELETE
+- `http://localhost:8080/bangazonAPI/v1/producttypes/[unique_product_type_id]`
+- Deletes one product type by its unique product type id.
+    *note* - you will not be able to delete a product type if it is currently assigned to an existing product
+#### POST
+- `http://localhost:8080/bangazonAPI/v1/producttypes`
+- Takes a JSON object in the format specified above.
+#### PUT
+- `http://localhost:8080/bangazonAPI/v1/producttypes/[unique_product_type_id]`
+- Takes a JSON object in the format specified above.


### PR DESCRIPTION
Added product types to the readme because we added product types to the application and the requirements were to make functionality  for product types, and then add product types documentation to the read me. Now the app has product type functionality and you can find information about it in the readme. IF you look at the readme you can find instructions on how to work the functionality written for product types. the changes in this pull request are only reflecting the changes i made to the readme and only meet the requirements of needing to add documatation bout product types to the readme.